### PR TITLE
Enable full-auto by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Codex configuration files can be placed in the `~/.codex/` directory, supporting
 | Parameter           | Type    | Default    | Description                      | Available Options                                                                              |
 | ------------------- | ------- | ---------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `model`             | string  | `o4-mini`  | AI model to use                  | Any model name supporting OpenAI API                                                           |
-| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
+| `approvalMode`      | string  | `full-auto`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
 | `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed)               |
 | `notify`            | boolean | `true`     | Enable desktop notifications     | `true`/`false`                                                                                 |
 
@@ -366,7 +366,7 @@ In the `history` object, you can configure conversation history settings:
 
 ```yaml
 model: o4-mini
-approvalMode: suggest
+approvalMode: full-auto
 fullAutoErrorMode: ask-user
 notify: true
 ```
@@ -376,7 +376,7 @@ notify: true
 ```json
 {
   "model": "o4-mini",
-  "approvalMode": "suggest",
+  "approvalMode": "full-auto",
   "fullAutoErrorMode": "ask-user",
   "notify": true
 }

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -152,6 +152,7 @@ const cli = meow(
       },
       fullAuto: {
         type: "boolean",
+        default: true,
         description:
           "Automatically run commands in a sandbox; only prompt for failures.",
       },
@@ -159,7 +160,7 @@ const cli = meow(
         type: "string",
         aliases: ["a"],
         description:
-          "Determine the approval mode for Codex (default: suggest) Values: suggest, auto-edit, full-auto",
+          "Determine the approval mode for Codex (default: full-auto) Values: suggest, auto-edit, full-auto",
       },
       writableRoot: {
         type: "string",

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -45,7 +45,7 @@ if (!isVitest) {
 
 export const DEFAULT_AGENTIC_MODEL = "codex-mini-latest";
 export const DEFAULT_FULL_CONTEXT_MODEL = "gpt-4.1";
-export const DEFAULT_APPROVAL_MODE = AutoApprovalMode.SUGGEST;
+export const DEFAULT_APPROVAL_MODE = AutoApprovalMode.FULL_AUTO;
 export const DEFAULT_INSTRUCTIONS = "";
 
 // Default shell output limits
@@ -427,7 +427,10 @@ export const loadConfig = (
     provider: storedConfig.provider,
     instructions: combinedInstructions,
     notify: storedConfig.notify === true,
-    approvalMode: storedConfig.approvalMode,
+    approvalMode:
+      storedConfig.approvalMode === undefined
+        ? DEFAULT_APPROVAL_MODE
+        : storedConfig.approvalMode,
     tools: {
       shell: {
         maxBytes:

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -69,6 +69,7 @@ test("loads default config if files don't exist", () => {
   // so we need to make sure we check just these properties
   expect(config.model).toBe("codex-mini-latest");
   expect(config.instructions).toBe("");
+  expect(config.approvalMode).toBe(AutoApprovalMode.FULL_AUTO);
 });
 
 test("saves and loads config correctly", () => {


### PR DESCRIPTION
## Summary
- default to `AutoApprovalMode.FULL_AUTO`
- ensure config fallback uses the new default
- default `--full-auto` CLI flag to true
- update configuration docs
- adjust config tests for the new default

## Testing
- `pnpm -r test` *(fails: rawExec – abort kills entire process group)*

------
https://chatgpt.com/codex/tasks/task_e_6840b5e5a5b0832bbae91ac06630ed46