### PR TITLE
Disable sandbox by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ files, and iterate - all under version control. In short, it's _chat-driven
 development_ that understands and executes your repo.
 
 - **Zero setup** - bring your OpenAI API key and it just works!
-- **Full auto-approval, while safe + secure** by running network-disabled and directory-sandboxed
+- **Full auto-approval by default** with no sandbox restrictions
 - **Multimodal** - pass in screenshots or diagrams to implement features ✨
 
 And it's **fully open-source** so you can see and contribute to how it develops!
@@ -165,14 +165,13 @@ And it's **fully open-source** so you can see and contribute to how it develops!
 Codex lets you decide _how much autonomy_ the agent receives and auto-approval policy via the
 `--approval-mode` flag (or the interactive onboarding prompt):
 
-| Mode                      | What the agent may do without asking                                                                | Still requires approval                                                                         |
-| ------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Suggest** <br>(default) | <li>Read any file in the repo                                                                       | <li>**All** file writes/patches<li> **Any** arbitrary shell commands (aside from reading files) |
-| **Auto Edit**             | <li>Read **and** apply-patch writes to files                                                        | <li>**All** shell commands                                                                      |
-| **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | -                                                                                               |
+| Mode                      | What the agent may do without asking                                       | Still requires approval                                                                         |
+| ------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Suggest** <br>(default) | <li>Read any file in the repo                                              | <li>**All** file writes/patches<li> **Any** arbitrary shell commands (aside from reading files) |
+| **Auto Edit**             | <li>Read **and** apply-patch writes to files                               | <li>**All** shell commands                                                                      |
+| **Full Auto**             | <li>Read/write files <li> Execute shell commands (no sandbox restrictions) | -                                                                                               |
 
-In **Full Auto** every command is run **network-disabled** and confined to the
-current working directory (plus temporary files) for defense-in-depth. Codex
+In **Full Auto** every command runs without sandbox restrictions. Codex
 will also show a warning/confirmation if you start in **auto-edit** or
 **full-auto** while the directory is _not_ tracked by Git, so you always have a
 safety net.
@@ -184,19 +183,12 @@ the network enabled, once we're confident in additional safeguards.
 
 The hardening mechanism Codex uses depends on your OS:
 
-- **macOS 12+** - commands are wrapped with **Apple Seatbelt** (`sandbox-exec`).
+- **macOS 12+** - you may run commands under **Apple Seatbelt** (`sandbox-exec`).
 
   - Everything is placed in a read-only jail except for a small set of
     writable roots (`$PWD`, `$TMPDIR`, `~/.codex`, etc.).
-  - Outbound network is _fully blocked_ by default - even if a child process
-    tries to `curl` somewhere it will fail.
 
-- **Linux** - there is no sandboxing by default.
-  We recommend using Docker for sandboxing, where Codex launches itself inside a **minimal
-  container image** and mounts your repo _read/write_ at the same path. A
-  custom `iptables`/`ipset` firewall script denies all egress except the
-  OpenAI API. This gives you deterministic, reproducible runs without needing
-  root on the host. You can use the [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
+- **Linux** - there is no sandboxing by default. You can use Docker for sandboxing, where Codex launches itself inside a **minimal** container image and mounts your repo _read/write_ at the same path. A custom `iptables`/`ipset` firewall script denies all egress except the OpenAI API. This gives you deterministic, reproducible runs without needing root on the host. You can use the [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
 
 > **Note:** Earlier versions relied on the `CODEX_UNSAFE_ALLOW_NO_SANDBOX` environment variable to bypass sandboxing inside Docker. This variable is now obsolete and ignored.
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -379,7 +379,7 @@ impl Config {
                     // permissions whatsoever.
                     Some(permissions) => SandboxPolicy::from(permissions),
                     // Default to read only rather than completely locked down.
-                    None => SandboxPolicy::new_read_only_policy(),
+                    None => SandboxPolicy::new_unrestricted_policy(),
                 }
             }
         };
@@ -786,7 +786,7 @@ disable_response_storage = true
                 model_provider_id: "openai".to_string(),
                 model_provider: fixture.openai_provider.clone(),
                 approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                sandbox_policy: SandboxPolicy::new_unrestricted_policy(),
                 shell_environment_policy: ShellEnvironmentPolicy::default(),
                 disable_response_storage: false,
                 instructions: None,
@@ -828,7 +828,7 @@ disable_response_storage = true
             model_provider_id: "openai-chat-completions".to_string(),
             model_provider: fixture.openai_chat_completions_provider.clone(),
             approval_policy: AskForApproval::UnlessAllowListed,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            sandbox_policy: SandboxPolicy::new_unrestricted_policy(),
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             disable_response_storage: false,
             instructions: None,
@@ -885,7 +885,7 @@ disable_response_storage = true
             model_provider_id: "openai".to_string(),
             model_provider: fixture.openai_provider.clone(),
             approval_policy: AskForApproval::OnFailure,
-            sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            sandbox_policy: SandboxPolicy::new_unrestricted_policy(),
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             disable_response_storage: true,
             instructions: None,

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -176,6 +176,17 @@ impl SandboxPolicy {
         }
     }
 
+    /// Grant unrestricted disk and network access.
+    pub fn new_unrestricted_policy() -> Self {
+        Self {
+            permissions: vec![
+                SandboxPermission::DiskFullReadAccess,
+                SandboxPermission::DiskFullWriteAccess,
+                SandboxPermission::NetworkFullAccess,
+            ],
+        }
+    }
+
     pub fn has_full_disk_read_access(&self) -> bool {
         self.permissions
             .iter()


### PR DESCRIPTION
## Summary
- remove sandboxing from default docs
- default to `new_unrestricted_policy` in Rust config
- add new `new_unrestricted_policy` helper

## Testing
- `pnpm test` *(fails: rawExec abort kills entire process group)*
- `cargo test` *(fails: config tests expecting old sandbox policy)*

------
https://chatgpt.com/codex/tasks/task_e_6841ada1239c832b8c09a07245969969